### PR TITLE
Add optional reporting param submit_issues

### DIFF
--- a/doc/usage/file_structure.rst
+++ b/doc/usage/file_structure.rst
@@ -79,6 +79,7 @@ Test plan
     * **type** (`str`) -- Name of reporting should be used while executing the test plan.
     * **condition** (`str`) -- Jinja2 expression used to determine when this reporting definition should be used. One may limit using the reporting only in cases of some events.
     * **group_by** (`list`) -- List of testcases configuration keys based on which the reporting should be grouped.
+    * **submit_issues** (`bool`) -- Tells issue analyzers to submit found issues during reporting.
     * **data** -- Data consumed by automation for purposes of reporting done by the used reporting type. There's no type restriction for this structure.
 
   * **configurations** (`list`, `inherited`, `optional`) --

--- a/tplib/structures/testplan.py
+++ b/tplib/structures/testplan.py
@@ -47,6 +47,7 @@ class Reporting(DataObject):
         m('type'),
         m('condition', required=False),
         m('group_by', required=False, func=GroupBy),
+        m('submit_issues', required=False, allowed_types=bool),
         m('data', required=False, allowed_types=object),
     ))
 


### PR DESCRIPTION
This makes it much simpler to access optional data in cases
when there is no required data.